### PR TITLE
Transform keys update

### DIFF
--- a/lib/utilise/augment/hash.rb
+++ b/lib/utilise/augment/hash.rb
@@ -6,32 +6,32 @@ module Utilise
     module Hash
       # Transforms all keys to snake case
       def snake_keys
-        transform_keys(self) { |key| key.snake }
+        utilise_deep_transform_keys(self) { |key| key.snake }
       end
 
       # Transforms all keys to camel case
       def camel_keys
-        transform_keys(self) { |key| key.camel }
+        utilise_deep_transform_keys(self) { |key| key.camel }
       end
 
       # Transforms all keys to space case
       def space_keys
-        transform_keys(self) { |key| key.space }
+        utilise_deep_transform_keys(self) { |key| key.space }
       end
 
       private
 
-      # Deep transform keys
+      # Deep transform keys in object
       # An awesome piece of code from rails
-      # apidock.com/rails/v4.2.1/Hash/_deep_transform_keys_in_object%21
-      def transform_keys(object, &block)
+      # http://apidock.com/rails/Hash/_deep_transform_keys_in_object
+      def utilise_deep_transform_keys(object, &block)
         case object
         when Hash
           object.each_with_object({}) do |(key, value), result|
-            result[yield(key)] = transform_keys(value, &block)
+            result[yield(key)] = utilise_deep_transform_keys(value, &block)
           end
         when Array
-          object.map { |e| transform_keys(e, &block) }
+          object.map { |e| utilise_deep_transform_keys(e, &block) }
         else
           object
         end

--- a/lib/utilise/version.rb
+++ b/lib/utilise/version.rb
@@ -1,9 +1,9 @@
 # Utilise
 module Utilise
   # The current gem version
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
   # The version update date
-  DATE = '2015-09-16'
+  DATE = '2015-10-06'
   # Debug output message
   MSG = 'Version %s %s (running on %s-%s)'
 

--- a/spec/utilise/version_spec.rb
+++ b/spec/utilise/version_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Utilise do
   describe '.version' do
     it 'should return the current gem version' do
-      expect(Utilise.version).to eq('0.6.1')
+      expect(Utilise.version).to eq('0.6.2')
     end
 
     it 'should return the current gem version with debug information' do


### PR DESCRIPTION
- Updated transform keys method as when used with active record it clashes
- Updated to version 0.6.2

