### PR TITLE
Adding lower option to the camel method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - ruby-head
+- 2.3.0
 - 2.2.0
 - 2.1.0
 - 2.0.0

--- a/lib/utilise/augment/bool.rb
+++ b/lib/utilise/augment/bool.rb
@@ -8,7 +8,7 @@ module Utilise
       # @return [Object] returns object boolean
       def to_bool(object = self)
         case object
-        when String, Fixnum, Symbol
+        when String, Integer, Symbol
           bool_it object
         when Hash
           bool_hash object

--- a/lib/utilise/augment/crash.rb
+++ b/lib/utilise/augment/crash.rb
@@ -8,7 +8,7 @@ module Utilise
       class Bash < Hashie::Mash
         # The default proc to be used for the bash hash
         DEFAULT_PROC = lambda do |hash, key|
-          fail NameError, "No key '#{key}' in #{hash.to_hash.inspect}"
+          raise NameError, "No key '#{key}' in #{hash.to_hash.inspect}"
         end
 
         def initialize(source_hash = nil, default = nil, &blk)

--- a/lib/utilise/augment/matchers.rb
+++ b/lib/utilise/augment/matchers.rb
@@ -3,11 +3,11 @@ module Utilise
     # Extends classes that could be queried as a boolean
     module Matchers
       def bool?
-        self.is_a?(TrueClass) || self.is_a?(FalseClass)
+        is_a?(TrueClass) || is_a?(FalseClass)
       end
 
       # NOTE: This keeps backwards compatibility
-      alias_method :is_bool?, :bool?
+      alias is_bool? bool?
     end
   end
 end

--- a/lib/utilise/augment/modify.rb
+++ b/lib/utilise/augment/modify.rb
@@ -3,9 +3,14 @@ module Utilise
     # Extends classes that could be modified
     module Modify
       # Return a string in modified camel case
-      def camel
+      def camel(first_letter = :upper)
         array = split_up
-        array.first + array[1..-1].map(&:capitalize).join('')
+        case first_letter
+        when :upper
+          array.map(&:capitalize).join
+        when :lower
+          array.first + array[1..-1].map(&:capitalize).join
+        end
       end
 
       # Return a string in snake case

--- a/lib/utilise/fixnum.rb
+++ b/lib/utilise/fixnum.rb
@@ -1,6 +1,6 @@
 require 'utilise/augment/bool'
 
 # Extend existing ruby class Fixnum
-class Fixnum
+class Integer
   include Utilise::Augment::Bool
 end

--- a/lib/utilise/version.rb
+++ b/lib/utilise/version.rb
@@ -1,7 +1,7 @@
 # Utilise
 module Utilise
   # The current gem version
-  VERSION = '0.6.2'
+  VERSION = '1.0.0'
   # The version update date
   DATE = '2015-10-06'
   # Debug output message

--- a/lib/utilise/version.rb
+++ b/lib/utilise/version.rb
@@ -1,11 +1,11 @@
 # Utilise
 module Utilise
   # The current gem version
-  VERSION = '1.0.0'
+  VERSION = '1.0.0'.freeze
   # The version update date
-  DATE = '2015-10-06'
+  DATE = '2015-10-06'.freeze
   # Debug output message
-  MSG = 'Version %s %s (running on %s-%s)'
+  MSG = 'Version %s %s (running on %s-%s)'.freeze
 
   module_function
 

--- a/spec/utilise/fixnum_spec.rb
+++ b/spec/utilise/fixnum_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Fixnum do
+describe Integer do
   describe '#to_bool' do
     it 'returns true when 1' do
       expect(1.to_bool).to be true

--- a/spec/utilise/hash_spec.rb
+++ b/spec/utilise/hash_spec.rb
@@ -118,10 +118,10 @@ describe Hash do
 
     it 'coverts all keys to camel case' do
       new_hash = hash.camel_keys
-      expect(new_hash.key?('oneKey')).to be_truthy
-      expect(new_hash.key?('twoKey')).to be_truthy
-      expect(new_hash.key?('redKey')).to be_truthy
-      expect(new_hash['redKey'].key?('blueKey')).to be_truthy
+      expect(new_hash.key?('OneKey')).to be_truthy
+      expect(new_hash.key?('TwoKey')).to be_truthy
+      expect(new_hash.key?('RedKey')).to be_truthy
+      expect(new_hash['RedKey'].key?('BlueKey')).to be_truthy
     end
 
     it 'does not transfer the old keys' do
@@ -134,10 +134,10 @@ describe Hash do
     it 'does not convert the values' do
       new_hash = hash.camel_keys
 
-      expect(new_hash['oneKey']).to eql('aString')
-      expect(new_hash['twoKey']).to eql(['a_string'])
-      expect(new_hash['redKey']).to be_a(Hash)
-      expect(new_hash['redKey']['blueKey']).to eql('testing 123')
+      expect(new_hash['OneKey']).to eql('aString')
+      expect(new_hash['TwoKey']).to eql(['a_string'])
+      expect(new_hash['RedKey']).to be_a(Hash)
+      expect(new_hash['RedKey']['BlueKey']).to eql('testing 123')
     end
 
     it 'does not modify the original hash' do

--- a/spec/utilise/string_spec.rb
+++ b/spec/utilise/string_spec.rb
@@ -44,32 +44,64 @@ describe String do
   end
 
   describe '#camel' do
-    it 'returns a camel case from camel case' do
-      expect('CamelCase'.camel).to eq 'camelCase'
+    context 'default option' do
+      it 'returns a camel case from camel case' do
+        expect('CamelCase'.camel).to eq 'CamelCase'
+      end
+
+      it 'returns a camel case from numeric camel case' do
+        expect('Camel1Case'.camel).to eq 'Camel1Case'
+      end
+
+      it 'returns a camel case from snake case' do
+        expect('camel_case'.camel).to eq 'CamelCase'
+      end
+
+      it 'returns a camel case from numeric snake case' do
+        expect('camel1_case'.camel).to eq 'Camel1Case'
+      end
+
+      it 'returns a camel case from space case' do
+        expect('camel case'.camel).to eq 'CamelCase'
+      end
+
+      it 'returns a camel case from numeric space case' do
+        expect('camel1 case'.camel).to eq 'Camel1Case'
+      end
+
+      it 'returns a camel case from complex camel case' do
+        expect('CamelONECase'.camel).to eq 'CamelOneCase'
+      end
     end
 
-    it 'returns a camel case from numeric camel case' do
-      expect('Camel1Case'.camel).to eq 'camel1Case'
-    end
+    context 'lower option' do
+      it 'returns a camel case from camel case' do
+        expect('CamelCase'.camel(:lower)).to eq 'camelCase'
+      end
 
-    it 'returns a camel case from snake case' do
-      expect('camel_case'.camel).to eq 'camelCase'
-    end
+      it 'returns a camel case from numeric camel case' do
+        expect('Camel1Case'.camel(:lower)).to eq 'camel1Case'
+      end
 
-    it 'returns a camel case from numeric snake case' do
-      expect('camel1_case'.camel).to eq 'camel1Case'
-    end
+      it 'returns a camel case from snake case' do
+        expect('camel_case'.camel(:lower)).to eq 'camelCase'
+      end
 
-    it 'returns a camel case from space case' do
-      expect('camel case'.camel).to eq 'camelCase'
-    end
+      it 'returns a camel case from numeric snake case' do
+        expect('camel1_case'.camel(:lower)).to eq 'camel1Case'
+      end
 
-    it 'returns a camel case from numeric space case' do
-      expect('camel1 case'.camel).to eq 'camel1Case'
-    end
+      it 'returns a camel case from space case' do
+        expect('camel case'.camel(:lower)).to eq 'camelCase'
+      end
 
-    it 'returns a camel case from complex camel case' do
-      expect('CamelONECase'.camel).to eq 'camelOneCase'
+      it 'returns a camel case from numeric space case' do
+        expect('camel1 case'.camel(:lower)).to eq 'camel1Case'
+      end
+
+      it 'returns a camel case from complex camel case' do
+        expect('CamelONECase'.camel(:lower)).to eq 'camelOneCase'
+      end
     end
   end
 

--- a/spec/utilise/time_spec.rb
+++ b/spec/utilise/time_spec.rb
@@ -7,7 +7,7 @@ describe Time do
     end
 
     it 'returns a string number' do
-      expect(Time.unique.to_i.class).to be Fixnum
+      expect(Time.unique).to match(/\d+/)
     end
 
     it 'returns a number from time to 3 decimal places' do

--- a/spec/utilise/version_spec.rb
+++ b/spec/utilise/version_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Utilise do
   describe '.version' do
     it 'should return the current gem version' do
-      expect(Utilise.version).to eq('0.6.2')
+      expect(Utilise.version).to eq('1.0.0')
     end
 
     it 'should return the current gem version with debug information' do


### PR DESCRIPTION
This PR is to add the option to have the final word in camel case starting with upper case character or lower case. Example:

1. By default the behavior is `"camel case".camel`  # => "CamelCase";
2. Passing the `:lower` symbol as a parameter to the method `"camel case".camel(:lower)`  # => "camelCase";